### PR TITLE
Improve integration of LSP, completion and Copilot

### DIFF
--- a/lua/lsp/attach.lua
+++ b/lua/lsp/attach.lua
@@ -4,6 +4,11 @@ function M.setup()
   vim.api.nvim_create_autocmd('LspAttach', {
     group = vim.api.nvim_create_augroup('lsp-attach', { clear = true }),
     callback = function(event)
+      -- Don't attach any LSP to diffview buffers
+      local bufname = vim.api.nvim_buf_get_name(event.buf)
+      if bufname:match('^diffview://') then
+        return
+      end
       require('lsp.keymaps').setup(event.data.client_id, event.buf)
 
       -- The following two autocommands are used to highlight references of the

--- a/lua/lsp/attach.lua
+++ b/lua/lsp/attach.lua
@@ -4,9 +4,10 @@ function M.setup()
   vim.api.nvim_create_autocmd('LspAttach', {
     group = vim.api.nvim_create_augroup('lsp-attach', { clear = true }),
     callback = function(event)
-      -- Don't attach any LSP to diffview buffers
+      -- Don't attach any LSP to diffview or mini.files buffers
       local bufname = vim.api.nvim_buf_get_name(event.buf)
-      if bufname:match('^diffview://') then
+      local filetype = vim.bo[event.buf].filetype
+      if bufname:match('^diffview://') or filetype == 'minifiles' then
         return
       end
       require('lsp.keymaps').setup(event.data.client_id, event.buf)

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -8,6 +8,15 @@ function M.setup()
   vim.lsp.config('*', {
     capabilities = capabilities,
     on_attach = require('lsp.attach').setup(),
+    root_dir = function(bufnr)
+      -- Don't attach to diffview buffers
+      local bufname = vim.api.nvim_buf_get_name(bufnr)
+      if bufname:match('^diffview://') then
+        return nil
+      end
+      -- Return current working directory for other files
+      return vim.fn.getcwd()
+    end,
   })
 
   local servers = require 'lsp.servers'

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -9,9 +9,10 @@ function M.setup()
     capabilities = capabilities,
     on_attach = require('lsp.attach').setup(),
     root_dir = function(bufnr)
-      -- Don't attach to diffview buffers
+      -- Don't attach to diffview or mini.files buffers
       local bufname = vim.api.nvim_buf_get_name(bufnr)
-      if bufname:match('^diffview://') then
+      local filetype = vim.bo[bufnr].filetype
+      if bufname:match('^diffview://') or filetype == 'minifiles' then
         return nil
       end
       -- Return current working directory for other files

--- a/lua/plugins/blink.lua
+++ b/lua/plugins/blink.lua
@@ -29,4 +29,16 @@ return {
     fuzzy = { implementation = 'prefer_rust_with_warning' },
   },
   opts_extend = { 'sources.default' },
+  
+  config = function(_, opts)
+    require('blink.cmp').setup(opts)
+    
+    -- Disable completion for specific filetypes
+    vim.api.nvim_create_autocmd('FileType', {
+      pattern = { 'minifiles', 'DiffviewFiles', 'DiffviewFileHistory' },
+      callback = function()
+        vim.b.completion = false
+      end,
+    })
+  end,
 }

--- a/lua/plugins/copilot.lua
+++ b/lua/plugins/copilot.lua
@@ -5,6 +5,13 @@ return {
   config = function()
     local copilot_enabled = true
 
+    -- Disable copilot for specific filetypes
+    vim.g.copilot_filetypes = {
+      ['minifiles'] = false,
+      ['DiffviewFiles'] = false,
+      ['DiffviewFileHistory'] = false,
+    }
+
     function ToggleCopilot()
       if copilot_enabled == true then
         copilot_enabled = false


### PR DESCRIPTION
This pull request improves the integration of LSP, completion, and Copilot plugins by preventing them from attaching to buffers related to Diffview and mini.files. These changes help avoid unnecessary or unwanted plugin behavior in special buffers, leading to a smoother user experience.

**LSP integration improvements:**

* Updated `lua/lsp/attach.lua` to prevent LSP from attaching to buffers with names starting with `diffview://` or with the `minifiles` filetype.
* Modified `lua/lsp/init.lua` to add a custom `root_dir` function that returns `nil` for Diffview and mini.files buffers, effectively disabling LSP attachment for them.

**Plugin configuration enhancements:**

* Added configuration to `lua/plugins/blink.lua` to disable completion for the `minifiles`, `DiffviewFiles`, and `DiffviewFileHistory` filetypes using an autocmd.
* Updated `lua/plugins/copilot.lua` to disable Copilot for the same special filetypes by setting `vim.g.copilot_filetypes`.